### PR TITLE
refactor: 글 작성 페이지, 헤더 UX 개선

### DIFF
--- a/app/(with-header)/post/create/page.tsx
+++ b/app/(with-header)/post/create/page.tsx
@@ -23,6 +23,7 @@ export default function Page() {
   const [content, setContent] = useState<string>('');
   const [isCountryModalOpen, setIsCountryModalOpen] = useState<boolean>(false);
   const [images, setImages] = useState<File[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const router = useRouter();
   const { user } = useUserStore();
 
@@ -36,40 +37,46 @@ export default function Page() {
   };
 
   async function handleSubmit() {
+    if (isSubmitting) return;
     if (!isFormValid) return;
     if (!user) {
       alert('로그인이 필요합니다.');
       return;
     }
-    const formData = new FormData();
+    setIsSubmitting(true);
+    try {
+      const formData = new FormData();
 
-    formData.append('post_type', selectedCategory);
-    formData.append('title', title);
-    formData.append('content', content);
+      formData.append('post_type', selectedCategory);
+      formData.append('title', title);
+      formData.append('content', content);
 
-    selectedCountries.forEach((country) => {
-      formData.append('countries', country.name);
-    });
+      selectedCountries.forEach((country) => {
+        formData.append('countries', country.name);
+      });
 
-    if (selectedTopic) {
-      formData.append('tags', selectedTopic);
+      if (selectedTopic) {
+        formData.append('tags', selectedTopic);
+      }
+
+      images.forEach((img) => {
+        formData.append('images', img);
+      });
+
+      const res = await fetch('/api/posts', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!res.ok) {
+        alert('게시글 작성 실패');
+        return;
+      }
+      alert('게시글이 성공적으로 작성되었습니다!');
+      router.push('/');
+    } finally {
+      setIsSubmitting(false);
     }
-
-    images.forEach((img) => {
-      formData.append('images', img);
-    });
-
-    const res = await fetch('/api/posts', {
-      method: 'POST',
-      body: formData,
-    });
-
-    if (!res.ok) {
-      alert('게시글 작성 실패');
-      return;
-    }
-    alert('게시글이 성공적으로 작성되었습니다!');
-    router.push('/');
   }
 
   return (
@@ -218,9 +225,11 @@ export default function Page() {
       <div className="fixed bottom-0 left-0 w-full">
         <div className="mx-auto max-w-[600px]">
           <SubmitButton
-            disabled={!isFormValid}
-            allowClickWhenDisabled
+            text={isSubmitting ? '업로드중입니다...' : '작성 완료'}
+            disabled={!isFormValid || isSubmitting}
+            allowClickWhenDisabled={!isSubmitting}
             onClick={() => {
+              if (isSubmitting) return;
               if (!isFormValid) {
                 alert('필수 항목을 모두 입력해주세요.');
                 return;

--- a/app/(with-header)/review/create/page.tsx
+++ b/app/(with-header)/review/create/page.tsx
@@ -17,50 +17,58 @@ function ReviewCreatePage() {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [dayReviews, setDayReviews] = useState<{ dayId: string; dayIndex: number; content: string }[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const isFormValid = selectedPlanId && title.trim() && content.trim() && images.length > 0;
 
   const handleSubmit = async () => {
+    if (isSubmitting) return;
+
     if (!isFormValid || !selectedPlanId) {
       alert('제목, 내용, 이미지, 일정을 모두 입력해주세요.');
       return;
     }
 
-    const formData = new FormData();
-    formData.append('plan_id', selectedPlanId);
-    formData.append('title', title);
-    formData.append('content', content);
-    formData.append(
-      'day_reviews',
-      JSON.stringify(
-        dayReviews.map((day) => ({
-          day_id: day.dayId,
-          day_index: day.dayIndex,
-          content: day.content,
-        })),
-      ),
-    );
+    setIsSubmitting(true);
+    try {
+      const formData = new FormData();
+      formData.append('plan_id', selectedPlanId);
+      formData.append('title', title);
+      formData.append('content', content);
+      formData.append(
+        'day_reviews',
+        JSON.stringify(
+          dayReviews.map((day) => ({
+            day_id: day.dayId,
+            day_index: day.dayIndex,
+            content: day.content,
+          })),
+        ),
+      );
 
-    images.forEach((img) => {
-      formData.append('images', img);
-    });
+      images.forEach((img) => {
+        formData.append('images', img);
+      });
 
-    const res = await fetch('/api/reviews', {
-      method: 'POST',
-      body: formData,
-    });
+      const res = await fetch('/api/reviews', {
+        method: 'POST',
+        body: formData,
+      });
 
-    if (!res.ok) {
-      alert('리뷰 작성 실패');
-      return;
+      if (!res.ok) {
+        alert('리뷰 작성 실패');
+        return;
+      }
+
+      const data = await res.json();
+      alert('리뷰가 성공적으로 작성되었습니다!');
+      if (data.review?.review_id) {
+        router.push(`/review/${data.review.review_id}`);
+        return;
+      }
+      router.push('/');
+    } finally {
+      setIsSubmitting(false);
     }
-
-    const data = await res.json();
-    alert('리뷰가 성공적으로 작성되었습니다!');
-    if (data.review?.review_id) {
-      router.push(`/review/${data.review.review_id}`);
-      return;
-    }
-    router.push('/');
   };
 
   useEffect(() => {
@@ -154,7 +162,12 @@ function ReviewCreatePage() {
 
       <div className="fixed bottom-0 left-0 w-full">
         <div className="mx-auto max-w-[600px]">
-          <SubmitButton disabled={!isFormValid} allowClickWhenDisabled onClick={handleSubmit} />
+          <SubmitButton
+            text={isSubmitting ? '업로드중입니다...' : '작성 완료'}
+            disabled={!isFormValid || isSubmitting}
+            allowClickWhenDisabled={!isSubmitting}
+            onClick={handleSubmit}
+          />
         </div>
       </div>
     </div>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,16 +1,37 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import type { User } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabase/client';
 import { useUserStore } from '@/stores/user-store';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  const { setUser, setLoading } = useUserStore();
+  const { setUser, setNickname, setLoading } = useUserStore();
+  const lastNicknameUserIdRef = useRef<string | null>(null);
 
   useEffect(() => {
+    const syncNickname = async (user: User | null) => {
+      if (!user) {
+        lastNicknameUserIdRef.current = null;
+        setNickname(null);
+        return;
+      }
+
+      // Prevent duplicate nickname lookups for the same user session.
+      if (lastNicknameUserIdRef.current === user.id) {
+        return;
+      }
+      lastNicknameUserIdRef.current = user.id;
+
+      const fallback = (user.user_metadata?.full_name as string | undefined) ?? null;
+      const { data: profile } = await supabase.from('users').select('nickname').eq('id', user.id).maybeSingle();
+      setNickname(profile?.nickname ?? fallback);
+    };
+
     // 초기 세션 동기화
     supabase.auth.getSession().then(({ data }) => {
       setUser(data.session?.user ?? null);
+      void syncNickname(data.session?.user ?? null);
       setLoading(false);
     });
 
@@ -19,6 +40,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
       setUser(session?.user ?? null);
+      void syncNickname(session?.user ?? null);
     });
 
     return () => {

--- a/components/buttons/submit-button.tsx
+++ b/components/buttons/submit-button.tsx
@@ -21,7 +21,9 @@ export default function SubmitButton({
       disabled={isBlocked}
       aria-disabled={disabled}
       onClick={onClick}
-      className={`text-regular14 h-12 w-full cursor-pointer transition ${disabled ? 'bg-gray-300 text-white' : 'bg-[#5364FF] text-white'} `}
+      className={`text-regular14 h-12 w-full transition ${
+        disabled ? 'bg-gray-300 text-white' : 'cursor-pointer bg-[#5364FF] text-white'
+      } `}
     >
       {text}
     </button>

--- a/components/floating-menu.tsx
+++ b/components/floating-menu.tsx
@@ -28,12 +28,13 @@ export default function FloatingMenu({ open, onClose }: FloatingMenuProps) {
       {open && (
         <>
           <motion.div
-            className="fixed inset-0 z-40 bg-black/20"
-            onClick={onClose}
+            className="fixed inset-0 z-40 flex justify-center"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-          />
+          >
+            <div className="h-full w-full max-w-[600px] bg-black/20" onClick={onClose} />
+          </motion.div>
 
           <motion.div
             className="fixed bottom-16 left-1/2 z-50 flex -translate-x-1/2 flex-col items-start gap-3 rounded-xl bg-[#4d4d4d] px-4 py-3 text-white shadow-lg"

--- a/components/headers/header.tsx
+++ b/components/headers/header.tsx
@@ -1,44 +1,20 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { supabase } from '@/lib/supabase/client';
 import BellIcon from '../../icons/bell-icon';
 import MenuIcon from '../../icons/menu-icon';
 import { useSidebarStore } from '@/stores/sidebar-store';
+import { useUserStore } from '@/stores/user-store';
 
 export default function Header() {
   const open = useSidebarStore((s) => s.open);
-  const [nickname, setNickname] = useState('여행자');
-
-  useEffect(() => {
-    let mounted = true;
-
-    async function loadNickname() {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-
-      if (!user) return;
-
-      const { data: profile } = await supabase.from('users').select('nickname').eq('id', user.id).maybeSingle();
-
-      if (mounted && profile?.nickname) {
-        setNickname(`여행자, ${profile.nickname}`);
-      }
-    }
-
-    loadNickname();
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
+  const nickname = useUserStore((s) => s.nickname);
+  const greeting = nickname ? `여행자, ${nickname}님!` : '여행자님!';
 
   return (
     <>
       <header className="fixed top-0 right-0 left-0 z-10 mx-auto flex h-12 max-w-[600px] items-center justify-between bg-white px-4">
-        <div className="text-medium18">{nickname}님!</div>
+        <div className="text-medium18">{greeting}</div>
 
         <div className="flex items-center gap-4">
           <Link href="/notice">

--- a/stores/user-store.ts
+++ b/stores/user-store.ts
@@ -5,15 +5,19 @@ import type { User } from '@supabase/supabase-js';
 
 type UserState = {
   user: User | null;
+  nickname: string | null;
   isLoading: boolean;
   setUser: (user: User | null) => void;
+  setNickname: (nickname: string | null) => void;
   setLoading: (loading: boolean) => void;
 };
 
 export const useUserStore = create<UserState>((set) => ({
   user: null,
+  nickname: null,
   isLoading: true,
 
   setUser: (user) => set({ user }),
+  setNickname: (nickname) => set({ nickname }),
   setLoading: (isLoading) => set({ isLoading }),
 }));


### PR DESCRIPTION
## Motivation

- 플로팅 메뉴 오버레이 범위가 전체 화면으로 적용되어있음
- 리뷰, 게시글 작성 시 중복 제출 가능한 문제 존재
- 리뷰, 게시글 작성 시 작성 완료 알림까지 아무런 피드백 없음
- 페이지 전환 시 헤더의 닉네임이 마운트되면서 깜빡임 문제

<br>

## Key Changes

- 플로팅 메뉴 오버레이 범위를 중앙 최대 600픽셀로 수정
- 리뷰, 게시글 작성 시 중복 제출 불가능 처리 및 '업로드중입니다...' 피드백 제공
- 헤더 닉네임 조회 전역 동기화로 전환

<br>

## Sreenshot

### [플로팅 메뉴 및 글 작성]

https://github.com/user-attachments/assets/60a8f254-a700-4235-8e09-0e97a24d7417



### [헤더 닉네임 마운트 UX 개선]
전 - 페이지(탭) 전환 시 Header가 마운트되면서 닉네임 조회가 매번 다시 호출됨
<img width="1034" height="375" alt="image" src="https://github.com/user-attachments/assets/f37b88a6-b4d4-4054-becb-028e680f72c7" />


후 - 페이지 전환에도 nickname은 한 번만 호출된 후 전역 동기화
<img width="1040" height="375" alt="image" src="https://github.com/user-attachments/assets/dfb54a2b-c183-412a-8333-ef325f0fe59f" />

전/후 UX 개선

https://github.com/user-attachments/assets/ffca9d9a-a0c2-4bf9-8b52-8ad24622bd3e


